### PR TITLE
Remove the duplicate key on 'line 11' causing errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "meteor run"
   },
   "bugs": "https://github.com/scorelab/SAMS/issues",
-  "description": "Salinity monitoring system",
   "author": "SCoRe Community",
   "contributors": [
     "agentmilindu",


### PR DESCRIPTION
The duplicate "description" key was removed which validated it as a **Valid JSON** according to [this following validator](http://jsonlint.com)